### PR TITLE
S5 size reduction & colab link fix

### DIFF
--- a/1-foundations/5-geospatial-analysis/foundations-s5-geo.ipynb
+++ b/1-foundations/5-geospatial-analysis/foundations-s5-geo.ipynb
@@ -7,7 +7,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/worldbank/dec-python-course/blob/s5-size-reduction-colab-link-fix/1-foundations/5-geospatial-analysis/foundations-s5-geo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/worldbank/dec-python-course/blob/main/1-foundations/5-geospatial-analysis/foundations-s5-geo.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {


### PR DESCRIPTION
- Currently the colab link on main points to session 4 – it's fixed in this PR.
- The file size currently stands at 11MB with the outputs. Removing them reduced it to 44KB. Also I recall @luisesanmartin correct me if I'm wrong, it was suggested that we remove all outputs to encourage participants to run the code themselves.

Side note, should this session be moved to the advanced topic folder?
